### PR TITLE
Add iOS UI and server backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ Press **`q`** to exit the recognition window.
 ## Notes
 
 This project uses OpenCV's built‑in Haar cascade for face detection and the LBPH face recognizer for identification. Ensure you have a webcam attached when running the scripts.
+
+## iOS Interface
+
+A basic SwiftUI application is available in the `ios/FaceRecUI` directory. It communicates with a small Python server (`server.py`) that exposes endpoints for collecting faces, training the model and recognizing faces from images.
+
+Run the server with:
+
+```bash
+python server.py
+```
+
+Open the Swift files in Xcode to build and run the iOS app.

--- a/ios/FaceRecUI/CameraView.swift
+++ b/ios/FaceRecUI/CameraView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import AVFoundation
+
+struct CameraView: UIViewControllerRepresentable {
+    var completion: (UIImage) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: CameraView
+        init(_ parent: CameraView) { self.parent = parent }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.completion(image)
+            }
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}

--- a/ios/FaceRecUI/ContentView.swift
+++ b/ios/FaceRecUI/ContentView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var showCollectCamera = false
+    @State private var showRecognizeCamera = false
+    @State private var label: String = ""
+    @State private var recognitionResult: String = ""
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                TextField("Person Label", text: $label)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+
+                Button("Collect Face") {
+                    showCollectCamera = true
+                }
+                .padding()
+
+                Button("Train Model") {
+                    RecognizerAPI.shared.train()
+                }
+                .padding()
+
+                Button("Recognize Face") {
+                    showRecognizeCamera = true
+                }
+                .padding()
+
+                Text(recognitionResult)
+                    .padding()
+            }
+            .navigationTitle("Face Recognition")
+            .sheet(isPresented: $showCollectCamera) {
+                CameraView { image in
+                    RecognizerAPI.shared.collect(label: label, image: image)
+                }
+            }
+            .sheet(isPresented: $showRecognizeCamera) {
+                CameraView { image in
+                    RecognizerAPI.shared.recognize(image: image) { result in
+                        recognitionResult = result
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ios/FaceRecUI/FaceRecApp.swift
+++ b/ios/FaceRecUI/FaceRecApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct FaceRecApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/FaceRecUI/RecognizerAPI.swift
+++ b/ios/FaceRecUI/RecognizerAPI.swift
@@ -1,0 +1,60 @@
+import UIKit
+
+class RecognizerAPI {
+    static let shared = RecognizerAPI()
+    private let baseURL = URL(string: "http://localhost:8000")!
+
+    func collect(label: String, image: UIImage) {
+        guard let url = URL(string: "/collect/\(label)", relativeTo: baseURL) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        let data = image.jpegData(compressionQuality: 0.8) ?? Data()
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"image\"; filename=\"image.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(data)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        URLSession.shared.dataTask(with: request).resume()
+    }
+
+    func train() {
+        guard let url = URL(string: "/train", relativeTo: baseURL) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        URLSession.shared.dataTask(with: request).resume()
+    }
+
+    func recognize(image: UIImage, completion: @escaping (String) -> Void) {
+        guard let url = URL(string: "/recognize", relativeTo: baseURL) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        let data = image.jpegData(compressionQuality: 0.8) ?? Data()
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"image\"; filename=\"image.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(data)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let results = json["results"] as? [[String: Any]],
+                  let first = results.first,
+                  let name = first["name"] as? String else { return }
+            DispatchQueue.main.async {
+                completion(name)
+            }
+        }.resume()
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,26 @@
+# iOS Interface
+
+This folder contains a simple SwiftUI application that communicates with a local
+Python server to perform face collection, training and recognition.
+
+## Setup
+
+1. Run the Python server:
+
+   ```bash
+   python server.py
+   ```
+
+   The server listens on `http://localhost:8000`.
+
+2. Open the Swift files in Xcode and build the app. The project uses three
+   simple views (`FaceRecApp.swift`, `ContentView.swift` and `CameraView.swift`)
+   and a helper `RecognizerAPI` class for network requests.
+
+3. The app lets you:
+
+   - Capture faces for a given label.
+   - Trigger training of the model.
+   - Capture a face for recognition.
+
+Make sure the device running the app can reach the server URL.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 opencv-python-headless>=4.5
 numpy
+flask

--- a/server.py
+++ b/server.py
@@ -1,0 +1,62 @@
+from flask import Flask, request, jsonify
+import os
+import cv2
+import numpy as np
+
+from train_model import train
+
+app = Flask(__name__)
+
+
+def save_uploaded_image(file, dir_path):
+    os.makedirs(dir_path, exist_ok=True)
+    index = len(os.listdir(dir_path)) + 1
+    file_path = os.path.join(dir_path, f"{index}.png")
+    file.save(file_path)
+    return file_path
+
+
+@app.route('/collect/<label>', methods=['POST'])
+def collect(label):
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image provided'}), 400
+    file = request.files['image']
+    save_dir = os.path.join('data', label)
+    path = save_uploaded_image(file, save_dir)
+    return jsonify({'saved': path})
+
+
+@app.route('/train', methods=['POST'])
+def train_route():
+    train()
+    return jsonify({'status': 'trained'})
+
+
+@app.route('/recognize', methods=['POST'])
+def recognize_route():
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image provided'}), 400
+    file = request.files['image']
+    model_path = request.form.get('model', 'trained_model.yml')
+    labels_path = request.form.get('labels', 'labels.npy')
+
+    img_array = np.frombuffer(file.read(), np.uint8)
+    img = cv2.imdecode(img_array, cv2.IMREAD_GRAYSCALE)
+    recognizer = cv2.face.LBPHFaceRecognizer_create()
+    recognizer.read(model_path)
+    label_map = np.load(labels_path, allow_pickle=True).item()
+    face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
+    faces = face_cascade.detectMultiScale(img, scaleFactor=1.3, minNeighbors=5)
+
+    results = []
+    for (x, y, w, h) in faces:
+        face_img = img[y:y+h, x:x+w]
+        label_id, confidence = recognizer.predict(face_img)
+        name = label_map.get(label_id, 'Unknown')
+        results.append({'name': name, 'confidence': float(confidence)})
+
+    return jsonify({'results': results})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add simple Flask server to serve face collection/training/recognition
- include a SwiftUI app (`ios/FaceRecUI`) that talks to the server
- document how to run the server and the iOS interface
- update requirements

## Testing
- `python -m py_compile collect_faces.py train_model.py recognize.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_68703ad10598833386216b5acc024b60